### PR TITLE
Userモデルに部署のQOLを確認する権限を追加し、新たに作成したDepartmentモデルと関連付けました

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,5 @@ yarn-debug.log*
 .yarn-integrity
 /vendor/bundle
 
-.DS-Store
+.DS_Store
 /db/seeds.rb

--- a/app/controllers/admin/departments_controller.rb
+++ b/app/controllers/admin/departments_controller.rb
@@ -1,0 +1,58 @@
+class Admin::DepartmentsController < ApplicationController
+  
+  before_action :authenticate_user!
+  before_action :set_department, only: %i( show edit update destroy )
+
+  def index
+    @departments = Department.all
+  end
+
+  def show
+  end
+
+  def new
+    @department = Department.new
+  end
+
+  def edit
+  end
+
+  def create
+    @department = Department.new(department_params)
+    if @department.save
+      redirect_to admin_departments_path, notice: "新たな部署として、「#{@department.name}」を登録しました。"
+    else
+      redirect_to admin_departments_path, alert: "新たな部署として「#{@department.name}」を登録できませんでした。"
+    end
+  end
+
+  def update
+    if @department.update(department_params)
+      redirect_to admin_departments_path, notice: "「#{@department.name}」の情報を更新しました。"
+    else
+      redirect_to admin_departments_path, alert: "「#{@department.name}」の情報を更新できませんでした。"
+    end
+  end
+
+  def destroy
+    if @department.destroy
+      redirect_to admin_departments_path, notice: "部署「#{@department.name}」の情報を削除しました。"
+    else
+      redirect_to admin_departments_path, alert: "部署「#{@department.name}」の情報を削除できませんでした。"
+    end
+  end
+
+  private
+
+  def department_params
+    params.require(:department).permit(:name, :description)
+  end
+
+  def set_department
+    @department = Department.find(params[:id])
+  end
+
+  def require_admin
+    redirect_to root_url unless current_user.admin?
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -45,7 +45,7 @@ class Admin::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :email, :admin, :password, :password_confirmation)
+    params.require(:user).permit(:name, :email, :admin, :department_id, :manager, :password, :password_confirmation)
   end
 
   def set_user

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -1,0 +1,6 @@
+class Department < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :description, length: { maximum: 255 }
+
+  has_many :users
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :questionnaires
+  belongs_to :department
 end

--- a/app/views/admin/departments/_form.html.slim
+++ b/app/views/admin/departments/_form.html.slim
@@ -1,0 +1,13 @@
+- if department.errors.present?
+  ul#error_explanation
+    - department.errors.full_messages.each do |message|
+      li= message
+
+= form_with model: [:admin, @department], local: true do |f|
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: 'form-control', id: 'department_name'
+  .form-group
+    = f.label :description
+    = f.text_area :description, rows: 4, class: 'form-control', id: 'department_description'
+  = f.submit '部署を登録する', class: 'btn btn-primary'

--- a/app/views/admin/departments/edit.html.slim
+++ b/app/views/admin/departments/edit.html.slim
@@ -1,0 +1,6 @@
+h1 部署の情報を編集する
+
+.nav.justify-content-end
+  = link_to '一覧', admin_departments_path, class: 'nav-link'
+
+= render partial: 'form', locals: { department: @department }

--- a/app/views/admin/departments/index.html.slim
+++ b/app/views/admin/departments/index.html.slim
@@ -1,0 +1,19 @@
+h1 部署一覧
+
+= link_to '部署の新規登録', new_admin_department_path, class: 'btn btn-primary'
+
+.mb-3
+table.table.table-hover
+  thead.thead-default
+    tr
+      th= Department.human_attribute_name(:name)
+      th= Department.human_attribute_name(:description)
+      th
+      th
+  tbody
+    - @departments.each do |department|
+      tr
+        td= link_to department.name, [:admin, department]
+        td= simple_format(department.description)
+        td= link_to '編集', edit_admin_department_path(department), class: 'btn btn-primary mr-3'
+        td= link_to '削除', [:admin, department], method: :delete, data: {confirm: "タスク「#{department.name}」を削除します。よろしいですか？"}, class: 'btn btn-danger'

--- a/app/views/admin/departments/new.html.slim
+++ b/app/views/admin/departments/new.html.slim
@@ -1,0 +1,6 @@
+h1 新たに部署を登録する
+
+.nav.justify-content-end
+  = link_to '一覧', admin_departments_path, class: 'nav-link'
+
+= render partial: 'form', locals: { department: @department }

--- a/app/views/admin/departments/show.html.slim
+++ b/app/views/admin/departments/show.html.slim
@@ -1,0 +1,24 @@
+h1 部署の詳細情報
+
+.nav.justify-content-end
+  = link_to '一覧', admin_departments_path, class: 'nav-link'
+table.table.table-hover
+  tbody
+    tr
+      th= Department.human_attribute_name(:id)
+      td= @department.id
+    tr
+      th= Department.human_attribute_name(:name)
+      td= @department.name
+    tr
+      th= Department.human_attribute_name(:description)
+      td= simple_format(h(@department.description), {}, sanitize: false, wrapper_tag: "div")
+    tr
+      th= Department.human_attribute_name(:created_at)
+      td= @department.created_at
+    tr
+      th= Department.human_attribute_name(:updated_at)
+      td= @department.updated_at
+
+= link_to '編集', edit_admin_department_path, class: 'btn btn-primary mr-3'
+= link_to '削除', [:admin, @department], method: :delete, data: { confirm: "部署「#{@department.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/admin/users/_form.html.slim
+++ b/app/views/admin/users/_form.html.slim
@@ -13,7 +13,14 @@
   .form-check
     = f.label :admin, class: 'form-check-label' do
       = f.check_box :admin, class: 'form-check-input'
-      | 管理者権限
+      | このアプリケーションの管理者権限を与える場合はチェックしてください
+  .form-for
+    =f.label :department_id, '所属部署'
+    =f.collection_select :department_id, Department.all, :id, :name, :prompt => true
+  .form-check
+    = f.label :manager, class: 'form-check-label' do
+      = f.check_box :manager, class: 'form-check-input'
+      | 部署全体のQOL値を確認できる権限を与える場合は、チェックしてください
   .form-group
     = f.label :password, 'パスワード'
     = f.password_field :password, class: 'form-control'

--- a/app/views/admin/users/index.html.slim
+++ b/app/views/admin/users/index.html.slim
@@ -9,8 +9,8 @@ table.table.table-hover
       th= User.human_attribute_name(:name)
       th= User.human_attribute_name(:email)
       th= User.human_attribute_name(:admin)
-      th= User.human_attribute_name(:created_at)
-      th= User.human_attribute_name(:updated_at)
+      th= User.human_attribute_name(:manager)
+      th
       th
   tbody
     - @users.each do |user|
@@ -18,8 +18,6 @@ table.table.table-hover
         td= link_to user.name, [:admin, user]
         td= user.email
         td= user.admin? ? 'あり' : 'なし'
-        td= user.created_at
-        td= user.updated_at
-        td
-          = link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary mr-3'
-          = link_to '削除', [:admin, user], method: :delete, data: { confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'
+        td= user.manager? ? 'あり' : 'なし'
+        td= link_to '編集', edit_admin_user_path(user), class: 'btn btn-primary mr-3'
+        td= link_to '削除', [:admin, user], method: :delete, data: { confirm: "ユーザー「#{user.name}」を削除します。よろしいですか？" }, class: 'btn btn-danger'

--- a/app/views/admin/users/show.html.slim
+++ b/app/views/admin/users/show.html.slim
@@ -17,6 +17,12 @@ table.table.table-hover
       th= User.human_attribute_name(:admin)
       td= @user.admin? ? 'あり' : 'なし'
     tr
+      th= '所属部署'
+      td= @user.department.name
+    tr
+      th= User.human_attribute_name(:manager)
+      td= @user.manager? ? 'あり' : 'なし'
+    tr
       th= User.human_attribute_name(:created_at)
       td= @user.created_at
     tr

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,8 +13,10 @@ html
 
       ul.navbar-nav.ml-auto
         - if current_user
+          li.nav-item= link_to 'トップ画面', root_path, class: 'nav-link'
           - if current_user.admin?
             li.nav-item= link_to 'ユーザー一覧', admin_users_path, class: 'nav-link'
+            li.nav-item= link_to '部署一覧', admin_departments_path, class: 'nav-link'
           li.nav-item= link_to 'ログアウト', destroy_user_session_path, method: :delete, class: 'nav-link'
         - else
           li.nav-item= link_to 'ログイン', new_user_session_path, class: 'nav-link'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -23,8 +23,14 @@ ja:
         name: 名前
         email: メールアドレス
         admin: 管理者権限
+        manager: QOL値確認権限
         password: パスワード
         password_confirmation: パスワード（確認）
+        created_at: 登録日時
+        updated_at: 更新日時
+      department:
+        name: 部署名
+        description: 部署の詳細情報
         created_at: 登録日時
         updated_at: 更新日時
   date:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 Rails.application.routes.draw do
 
   devise_for :users, only: [:sign_in, :sign_out, :session]
+
   namespace :admin do
     resources :users
+    resources :departments
   end
 
   root 'top#index'

--- a/db/migrate/20200519072414_create_departments.rb
+++ b/db/migrate/20200519072414_create_departments.rb
@@ -1,0 +1,10 @@
+class CreateDepartments < ActiveRecord::Migration[6.0]
+  def change
+    create_table :departments do |t|
+      t.string :name, null: false
+      t.string :description, null: false, default: ""
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200519171737_add_manager_to_users.rb
+++ b/db/migrate/20200519171737_add_manager_to_users.rb
@@ -1,0 +1,5 @@
+class AddManagerToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :manager, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20200519182242_add_department_id_to_users.rb
+++ b/db/migrate/20200519182242_add_department_id_to_users.rb
@@ -1,0 +1,10 @@
+class AddDepartmentIdToUsers < ActiveRecord::Migration[6.0]
+  def up
+    execute 'DELETE FROM users;'
+    add_reference :users, :department, null: false, index: true
+  end
+
+  def down
+    remove_reference :users, :department, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_19_000635) do
+ActiveRecord::Schema.define(version: 2020_05_19_182242) do
+
+  create_table "departments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "description", default: "", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
   create_table "questionnaires", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "mobility", null: false
@@ -34,6 +41,9 @@ ActiveRecord::Schema.define(version: 2020_05_19_000635) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "admin", default: false, null: false
+    t.boolean "manager", default: false, null: false
+    t.bigint "department_id", null: false
+    t.index ["department_id"], name: "index_users_on_department_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,0 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,9 +5,3 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-
-User.create(name: "井之上 裕樹",
-            email: "inoue.yuki@moneyforward.co.jp",
-            password: "11111111",
-            password_confirmation: "11111111",
-            admin: true)

--- a/test/controllers/admin/departments_controller_test.rb
+++ b/test/controllers/admin/departments_controller_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Admin::DepartmentsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get admin_departments_new_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get admin_departments_edit_url
+    assert_response :success
+  end
+
+  test "should get show" do
+    get admin_departments_show_url
+    assert_response :success
+  end
+
+  test "should get index" do
+    get admin_departments_index_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/departments.yml
+++ b/test/fixtures/departments.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  description: MyString
+
+two:
+  name: MyString
+  description: MyString

--- a/test/models/department_test.rb
+++ b/test/models/department_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DepartmentTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# 背景
管理者が、Userが所属する部署の情報を登録できるようにしたい。
また、Userが部署内の他者のQOLを確認できるか否か決めるためのフラグをつけたい。

# やったこと
Departmentモデルを追加し、部署名と部署の詳細情報を登録できるようにしました。
また、Userにmanagerカラムを追加しました。managerは部署に1人という指定をしておらず、部署とも紐づけていません。あくまでも、「QOLを確認できる人」というポジションです。
